### PR TITLE
feat: add `--ignore-func-signatures` flag to prevent wrapping function signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ the command provided here should accept its input via `stdin` and write its outp
 By default, the tool will not format any files that look like they're generated.
 If you want to reformat these too, run with the flag `--ignore-generated=false`.
 
+### Ignoring Function Signatures
+
+By default, the tool will format function signatures that exceed the maximum line length by splitting their parameters across multiple lines.
+To prevent this and keep function signatures on a single line, run with the flag `--ignore-func-signatures`.
+
 ### Chained method splitting
 
 There are several possible ways to split lines that are part of

--- a/main.go
+++ b/main.go
@@ -48,6 +48,9 @@ var (
 	ignoreGenerated = kingpin.Flag(
 		"ignore-generated",
 		"Ignore generated go files").Default("true").Bool()
+	ignoreFuncSignatures = kingpin.Flag(
+		"ignore-func-signatures",
+		"Ignore function signatures").Default("false").Bool()
 	ignoredDirs = kingpin.Flag(
 		"ignored-dirs",
 		"Directories to ignore").Default("vendor", "testdata", "node_modules").Strings()
@@ -151,13 +154,14 @@ type Runner struct {
 
 func NewRunner() *Runner {
 	config := &shorten.Config{
-		MaxLen:          deref(maxLen),
-		TabLen:          deref(tabLen),
-		KeepAnnotations: deref(keepAnnotations),
-		ShortenComments: deref(shortenComments),
-		ReformatTags:    deref(reformatTags),
-		DotFile:         deref(dotFile),
-		ChainSplitDots:  deref(chainSplitDots),
+		MaxLen:               deref(maxLen),
+		TabLen:               deref(tabLen),
+		KeepAnnotations:      deref(keepAnnotations),
+		ShortenComments:      deref(shortenComments),
+		ReformatTags:         deref(reformatTags),
+		DotFile:              deref(dotFile),
+		ChainSplitDots:       deref(chainSplitDots),
+		IgnoreFuncSignatures: deref(ignoreFuncSignatures),
 	}
 
 	return &Runner{

--- a/shorten/format.go
+++ b/shorten/format.go
@@ -51,7 +51,7 @@ func (s *Shortener) formatNode(node dst.Node) {
 func (s *Shortener) formatDecl(decl dst.Decl) {
 	switch d := decl.(type) {
 	case *dst.FuncDecl:
-		if d.Type != nil && d.Type.Params != nil && annotation.HasRecursive(d) {
+		if d.Type != nil && d.Type.Params != nil && annotation.HasRecursive(d) && !s.config.IgnoreFuncSignatures {
 			s.formatFieldList(d.Type.Params)
 		}
 
@@ -236,7 +236,7 @@ func (s *Shortener) formatExpr(expr dst.Expr, force, isChain bool) {
 		s.formatStmt(e.Body, false)
 
 	case *dst.FuncType:
-		if shouldShorten {
+		if shouldShorten && !s.config.IgnoreFuncSignatures {
 			s.formatFieldList(e.Params)
 		}
 

--- a/shorten/shortener.go
+++ b/shorten/shortener.go
@@ -42,18 +42,22 @@ type Config struct {
 
 	// ChainSplitDots Whether to split chain methods by putting dots at the ends of lines
 	ChainSplitDots bool
+
+	// IgnoreFuncSignatures Whether to ignore function signatures
+	IgnoreFuncSignatures bool
 }
 
 // NewDefaultConfig returns a [Config] with default values.
 func NewDefaultConfig() *Config {
 	return &Config{
-		MaxLen:          100,
-		TabLen:          4,
-		KeepAnnotations: false,
-		ShortenComments: false,
-		ReformatTags:    true,
-		DotFile:         "",
-		ChainSplitDots:  true,
+		MaxLen:               100,
+		TabLen:               4,
+		KeepAnnotations:      false,
+		ShortenComments:      false,
+		ReformatTags:         true,
+		DotFile:              "",
+		ChainSplitDots:       true,
+		IgnoreFuncSignatures: false,
 	}
 }
 

--- a/shorten/testdata/ignore_func_signatures/ignore_func_signatures.go
+++ b/shorten/testdata/ignore_func_signatures/ignore_func_signatures.go
@@ -1,0 +1,13 @@
+package ignore_func_signatures
+
+func aVeryLongFunctionNameThatExceedsTheLineLength(firstArg string, secondArg int, thirdArg bool, fourthArg float64) error {
+	return nil
+}
+
+type MyType struct{}
+
+func (m *MyType) AnotherVeryLongFunctionNameThatExceedsTheLineLength(firstArg string, secondArg int, thirdArg bool, fourthArg float64) error {
+	return nil
+}
+
+var myFuncType func(firstArg string, secondArg int, thirdArg bool, fourthArg float64) error

--- a/shorten/testdata/ignore_func_signatures/ignore_func_signatures.go.golden
+++ b/shorten/testdata/ignore_func_signatures/ignore_func_signatures.go.golden
@@ -1,0 +1,13 @@
+package ignore_func_signatures
+
+func aVeryLongFunctionNameThatExceedsTheLineLength(firstArg string, secondArg int, thirdArg bool, fourthArg float64) error {
+	return nil
+}
+
+type MyType struct{}
+
+func (m *MyType) AnotherVeryLongFunctionNameThatExceedsTheLineLength(firstArg string, secondArg int, thirdArg bool, fourthArg float64) error {
+	return nil
+}
+
+var myFuncType func(firstArg string, secondArg int, thirdArg bool, fourthArg float64) error

--- a/shorten/testdata/ignore_func_signatures/ignore_func_signatures.json
+++ b/shorten/testdata/ignore_func_signatures/ignore_func_signatures.json
@@ -1,0 +1,5 @@
+{
+    "MaxLen": 100,
+    "TabLen": 4,
+    "IgnoreFuncSignatures": true
+}


### PR DESCRIPTION
Addresses Discussion #31

### Description
This PR introduces a new boolean flag, `--ignore-func-signatures`, which allows users to bypass the line-shortening logic specifically for function declarations and function types.

By default, `golines` applies the `--max-len` limit uniformly across all AST nodes, which can force function signatures with multiple parameters to wrap across several lines. The Go standard library frequently keeps function signatures on a single line even when they exceed typical column limits (e.g., in `image/draw`).

This flag gives users the option to strictly format the bodies of their functions and structs to a specific length while maintaining idiomatic, single-line function signatures, eliminating the need to rely on `//golines:ignore` comments above every long signature.

### Changes Made
* Added the `--ignore-func-signatures` boolean flag (default: `false`) to the CLI.
* Threaded the new configuration option through `shorten.Config`.
* Updated `formatDecl` (`*dst.FuncDecl`) and `formatExpr` (`*dst.FuncType`) in `shorten/format.go` to conditionally bypass formatting the parameter list if the flag is enabled.
* Added a new E2E test case in `shorten/testdata/ignore_func_signatures` to verify the behavior.
* Updated `README.md` with documentation for the new flag.
